### PR TITLE
Fix type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,4 @@
-declare module 'mocha-param' {
-	export default function itParam(desc: string, data: Array<any>, callback: (...args: any) => void): void;
-}
+import { Done } from 'mocha'
+
+export default function itParam<T>(desc: string, data: T[], callback: (value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (done: Done, value: T) => void): void;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Parameterized tests for Mocha",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "mocha ./test/*.js"
   },


### PR DESCRIPTION
As mentioned in #9.

- The `declare module` syntax shouldn't be used
- I added definitions for the async callback overload
- Added the `types` option in `package.json` for good practice