### PR TITLE
Fix overload inference in type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
 import { Done } from 'mocha'
 
-export default function itParam<T>(desc: string, data: T[], callback: (value: T) => void): void;
 export default function itParam<T>(desc: string, data: T[], callback: (done: Done, value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (value: T) => void): void;


### PR DESCRIPTION
I just found out that the overloads in the type definitions need to be swapped [for the inference to work correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#ordering).

Sorry for the trouble!