### PR TITLE
Fix context (this) access inside callback

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import { Done } from 'mocha'
+import { Context, Done } from 'mocha'
 
-export default function itParam<T>(desc: string, data: T[], callback: (value: T) => void): void;
-export default function itParam<T>(desc: string, data: T[], callback: (done: Done, value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (this: Context, value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (this: Context, done: Done, value: T) => void): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 /*
  * The library is wrapped in a function (IIFE) that allows
  * mocha param to be required simply by using require('mocha-param')
- * but ensures backwards compatibility with those still using require('mocha-param').itParam 
+ * but ensures backwards compatibility with those still using require('mocha-param').itParam
  */
 module.exports = function (desc, data, callback) {
 
@@ -32,7 +32,7 @@ function run(desc, data, callback) {
 function callItSync(desc, data, callback) {
     data.forEach(function (val) {
         it(renderTemplate(desc, val), function () {
-            return callback(val);
+            return callback.bind(this)(val);
         });
     });
 
@@ -41,13 +41,13 @@ function callItSync(desc, data, callback) {
 function callItAsync(desc, data, callback) {
     data.forEach(function (val) {
         it(renderTemplate(desc, val), function (done) {
-            callback(done, val);
+            callback.bind(this)(done, val);
         });
     });
 }
 
 /*
- * Add value to description 
+ * Add value to description
  */
 function renderTemplate(template, value) {
     try {

--- a/test/index.js
+++ b/test/index.js
@@ -48,3 +48,17 @@ describe("Object literal in description should work", function () {
     });
 });
 
+describe("Context inside callback", function () {
+	beforeEach(function() {
+		this.customValue = 1;
+	});
+	
+	itParam('should be accessible (sync)', [1], function(value) {
+		expect(this.customValue).to.equal(1);
+	});
+	
+	itParam('should be accessible (async)', [1], function(done, value) {
+		expect(this.customValue).to.equal(1);
+		done();
+	});
+});


### PR DESCRIPTION
After about 4 hours of comparing `this` values, getting confused, trying *a lot* of things and more confusion, I **finally** found the (real) solution for #5.

Of course, in hindsight it's a very easy fix. It just took me hours to notice that the `callback` wasn't directly passed to mocha's `it`, giving me access to the `this`-context a normal `it` call would have.

Sleep at last...