### PR TITLE
Add test utilities (skip, only, retries) to itParam

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,14 +1,11 @@
-import { Context, Done } from 'mocha'
+import { Context, Done, TestFunction } from 'mocha'
 
 
 type ItParamTestFuncSync = <T>(desc: string, data: T[], callback: (this: Context, value: T) => void) => void;
 type ItParamTestFuncAsync = <T>(desc: string, data: T[], callback: (this: Context, done: Done, value: T) => void) => void;
 type ItParamTestFunc = ItParamTestFuncSync & ItParamTestFuncAsync;
 
-declare const itParam: ItParamTestFunc & {
-	skip: ItParamTestFunc;
-	only: ItParamTestFunc;
-	retries: ItParamTestFunc;
-}
+type Utilities = { [P in keyof TestFunction]: ItParamTestFunc };
 
+declare const itParam: ItParamTestFunc & Utilities;
 export default itParam;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,14 @@
 import { Context, Done } from 'mocha'
 
-export default function itParam<T>(desc: string, data: T[], callback: (this: Context, value: T) => void): void;
-export default function itParam<T>(desc: string, data: T[], callback: (this: Context, done: Done, value: T) => void): void;
+
+type ItParamTestFuncSync = <T>(desc: string, data: T[], callback: (this: Context, value: T) => void) => void;
+type ItParamTestFuncAsync = <T>(desc: string, data: T[], callback: (this: Context, done: Done, value: T) => void) => void;
+type ItParamTestFunc = ItParamTestFuncSync & ItParamTestFuncAsync;
+
+declare const itParam: ItParamTestFunc & {
+	skip: ItParamTestFunc;
+	only: ItParamTestFunc;
+	retries: ItParamTestFunc;
+}
+
+export default itParam;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import { Done } from 'mocha'
+import { Context, Done } from 'mocha'
 
-export default function itParam<T>(desc: string, data: T[], callback: (value: T) => void): void;
-export default function itParam<T>(desc: string, data: T[], callback: (done: Done, value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (this: Context, value: T) => void): void;
+export default function itParam<T>(desc: string, data: T[], callback: (this: Context, done: Done, value: T) => void): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,9 @@ module.exports = function (desc, data, callback) {
 	const wrapper = run;
 	wrapper.itParam = run;
 	
-	run.skip = (desc, data, callback) => run(desc, data, callback, it.skip);
-	run.only = (desc, data, callback) => run(desc, data, callback, it.only);
-	run.retries = (desc, data, callback) => run(desc, data, callback, it.retries);
+	Object.keys(it).forEach(utility => {
+		run[utility] = (desc, data, callback) => run(desc, data, callback, it[utility]);
+	});
 	
     return wrapper;
 }()

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 /*
  * The library is wrapped in a function (IIFE) that allows
  * mocha param to be required simply by using require('mocha-param')
- * but ensures backwards compatibility with those still using require('mocha-param').itParam 
+ * but ensures backwards compatibility with those still using require('mocha-param').itParam
  */
 module.exports = function (desc, data, callback) {
 
@@ -32,7 +32,7 @@ function run(desc, data, callback) {
 function callItSync(desc, data, callback) {
     data.forEach(function (val) {
         it(renderTemplate(desc, val), function () {
-            return callback(val);
+            return callback.bind(this)(val);
         });
     });
 
@@ -41,13 +41,13 @@ function callItSync(desc, data, callback) {
 function callItAsync(desc, data, callback) {
     data.forEach(function (val) {
         it(renderTemplate(desc, val), function (done) {
-            callback(done, val);
+            callback.bind(this)(done, val);
         });
     });
 }
 
 /*
- * Add value to description 
+ * Add value to description
  */
 function renderTemplate(template, value) {
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,13 @@
  * but ensures backwards compatibility with those still using require('mocha-param').itParam
  */
 module.exports = function (desc, data, callback) {
-
-    let wrapper = function (desc, data, callback) {
-        run(desc, data, callback);
-    };
-
-    wrapper.itParam = run;
+	const wrapper = run;
+	wrapper.itParam = run;
+	
+	run.skip = (desc, data, callback) => run(desc, data, callback, it.skip);
+	run.only = (desc, data, callback) => run(desc, data, callback, it.only);
+	run.retries = (desc, data, callback) => run(desc, data, callback, it.retries);
+	
     return wrapper;
 }()
 
@@ -21,26 +22,26 @@ module.exports = function (desc, data, callback) {
  * Call mocha "it" function either sync or async depending
  * on whether callback has one or two params
  */
-function run(desc, data, callback) {
+function run(desc, data, callback, executor) {
     if (callback.length === 2) {
-        callItAsync(desc, data, callback)
+        callItAsync(executor || it, desc, data, callback)
     } else {
-        callItSync(desc, data, callback)
+        callItSync(executor || it, desc, data, callback)
     }
 }
 
-function callItSync(desc, data, callback) {
+function callItSync(executor, desc, data, callback) {
     data.forEach(function (val) {
-        it(renderTemplate(desc, val), function () {
+        executor(renderTemplate(desc, val), function () {
             return callback.bind(this)(val);
         });
     });
 
 }
 
-function callItAsync(desc, data, callback) {
+function callItAsync(executor, desc, data, callback) {
     data.forEach(function (val) {
-        it(renderTemplate(desc, val), function (done) {
+        executor(renderTemplate(desc, val), function (done) {
             callback.bind(this)(done, val);
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -48,3 +48,17 @@ describe("Object literal in description should work", function () {
     });
 });
 
+describe("Context inside callback", function () {
+	beforeEach(function() {
+		this.customValue = 1;
+	});
+	
+	itParam('should be accessible (sync)', [1], function(value) {
+		expect(this.customValue).to.equal(1);
+	});
+	
+	itParam('should be accessible (async)', [1], function(done, value) {
+		expect(this.customValue).to.equal(1);
+		done();
+	});
+});

--- a/test/index.js
+++ b/test/index.js
@@ -69,3 +69,21 @@ describe("Context inside callback", function () {
 		done();
 	});
 });
+
+describe("Test function utilities", function () {
+	it('should exist', function () {
+		expect(itParam.retries).to.exist;
+		expect(itParam.skip).to.exist;
+		expect(itParam.only).to.exist;
+	});
+	
+	it('should exist (old import)', function () {
+		expect(itParamOld.retries).to.exist;
+		expect(itParamOld.skip).to.exist;
+		expect(itParamOld.only).to.exist;
+	});
+	
+	itParam.skip('should be skipped', [1], function(value) {
+		throw new Error('Test was not skipped');
+	});
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,14 @@
 var itParam = require('../lib/index');
+var itParamOld = require('../lib/index').itParam;
 
 var expect = require('chai').expect;
 
+
+describe("Using old-style import", function () {
+	itParamOld("should all pass", [1, 1, 1], function (value) {
+		expect(value).to.equal(1);
+	})
+});
 
 describe("Calling itParam in a loop sync with a value", function () {
     itParam("should all pass", [1, 1, 1], function (value) {


### PR DESCRIPTION
Title says it all, fixes #6.

This branch is based on #13, meaning it shouldn't be merged until that one's merged. I did this to avoid regressing the this-context shenanigans.

Defining these utility functions can be done manually (3f9f25c) or automatically (6521e2e), since `Object.keys(it)` (currently) returns just these three utility functions. This has the benefit of not having to update when mocha adds another utility function, but could potentially lead to undefined behavior if mocha adds something that is not a utility function.
The branch is currently contains the 'automatic' version, if you prefer the manual one I can revert it.

I opened this PR as a draft because I'm still working on the type definitions, unfortunately they're not as straightforward anymore.